### PR TITLE
Use https rather than ssh for gitmodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/asmacdo/docsy.git
 [submodule "website/assets"]
 	path = website/assets
-	url = git@github.com:asmacdo/docsy-overrides.git
+	url = https://github.com/asmacdo/docsy-overrides.git


### PR DESCRIPTION
Deploy preview failed to build: 
Error checking out submodules: Submodule 'website/assets' (git@github.com:asmacdo/docsy-overrides.git) registered for path 'website/assets'
Submodule 'website/themes/docsy' (https://github.com/asmacdo/docsy.git) registered for path 'website/themes/docsy'
Cloning into '/opt/build/repo/website/assets'...
Host key verification failed.

I should have used http for the submodule rather than ssh.